### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -4,7 +4,7 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 secret=$(ynh_string_random --length=24)
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 
 #=================================================
 # INSTALL DEPENDENCIES

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -4,7 +4,7 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 secret=$(ynh_string_random --length=24)
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 
 #=================================================
 # STOP SYSTEMD SERVICE


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.